### PR TITLE
Alternative representation of a cross section: CrossSectionAreasVT

### DIFF
--- a/src/fusedwind/examples/turbine/cs_area_example.py
+++ b/src/fusedwind/examples/turbine/cs_area_example.py
@@ -44,23 +44,6 @@ biax.G23 = 4.539e9
 biax.rho = 1845
 
 
-# add material coordinate systems
-esys_hori = cs_areas.add_csys('esys_hori') # for horizontal layers
-esys_hori.origin_x = 0.0
-esys_hori.origin_y = 0.0
-esys_hori.origin_z = 0.0
-esys_hori.theta_x = -90.0
-esys_hori.theta_y = 180.0
-esys_hori.theta_z = 90.0
-
-esys_vert = cs_areas.add_csys('esys_vert') # for -90deg oriented layers
-esys_vert.origin_x = 0.0
-esys_vert.origin_y = 0.0
-esys_vert.origin_z = 0.0
-esys_vert.theta_x = -180.0
-esys_vert.theta_y = 180.0
-esys_vert.theta_z = 90.0
-
 # add keypoints
 KP000 = cs_areas.add_kp('KP000')
 KP000.x = -0.1
@@ -106,8 +89,9 @@ cap_up.KPs = ['KP003',
               'KP001',
               'KP000'
               ]
-cap_up.mat_name = 'uniax'
-cap_up.esys_name = 'esys_hori'
+cap_up.mat = 'uniax'
+cap_up.fiber_plane_angle = .0
+cap_up.fiber_dir_angle = .0
 
 cap_low = cs_areas.add_area('cap_low')
 cap_low.KPs = ['KP009',
@@ -115,8 +99,9 @@ cap_low.KPs = ['KP009',
               'KP007',
               'KP006'
               ]
-cap_low.mat_name = 'uniax'
-cap_low.esys_name = 'esys_hori'
+cap_low.mat = 'uniax'
+cap_low.fiber_plane_angle = .0
+cap_low.fiber_dir_angle = .0
 
 web = cs_areas.add_area('web')
 web.KPs = ['KP010',
@@ -124,11 +109,12 @@ web.KPs = ['KP010',
               'KP005',
               'KP004'
               ]
-web.mat_name = 'biax'
-web.esys_name = 'esys_vert'
+web.mat = 'biax'
+web.fiber_plane_angle = -90.0
+web.fiber_dir_angle = -90.0
 
 # HOWTO access dict object
-print cs_areas.csysts['esys_vert'].origin_x
+#print cs_areas.csysts['esys_vert'].origin_x
 
 # HOWTO access list obejct
 kp = getattr(cs_areas, 'KP005')

--- a/src/fusedwind/examples/turbine/cs_area_example.py
+++ b/src/fusedwind/examples/turbine/cs_area_example.py
@@ -1,17 +1,7 @@
 
 # --- 1 -----
 
-import numpy as np
-
-from openmdao.lib.datatypes.api import VarTree
-from openmdao.main.api import Assembly, Component
-
-from fusedwind.interface import implement_base
-from fusedwind.turbine.geometry import read_blade_planform, redistribute_blade_planform
-from fusedwind.turbine.configurations import configure_bladestructure, configure_bladesurface
-from fusedwind.turbine.blade_structure import SplinedBladeStructure
-from fusedwind.turbine.structure_vt import BladeStructureVT3D, \
-    CrossSectionAreasVT
+from fusedwind.turbine.structure_vt import CrossSectionAreasVT
 
 #top = Assembly()
 
@@ -113,14 +103,12 @@ web.mat = 'biax'
 web.fiber_plane_angle = -90.0
 web.fiber_dir_angle = -90.0
 
-# HOWTO access dict object
-#print cs_areas.csysts['esys_vert'].origin_x
-
-# HOWTO access list obejct
+# HOWTO access single list object
 kp = getattr(cs_areas, 'KP005')
 print kp.x
 print kp.y
 
+# HOWTO access list obejct in for loop
 for kpname in cs_areas.KPs:
     print kpname
     kp = getattr(cs_areas, kpname)

--- a/src/fusedwind/examples/turbine/cs_mesh_example.py
+++ b/src/fusedwind/examples/turbine/cs_mesh_example.py
@@ -10,7 +10,7 @@ from fusedwind.interface import implement_base
 from fusedwind.turbine.geometry import read_blade_planform, redistribute_blade_planform
 from fusedwind.turbine.configurations import configure_bladestructure, configure_bladesurface
 from fusedwind.turbine.blade_structure import SplinedBladeStructure
-from fusedwind.turbine.structure_vt import BladeStructureVT3D, Csys,\
+from fusedwind.turbine.structure_vt import BladeStructureVT3D, \
     CrossSectionAreasVT
 
 #top = Assembly()

--- a/src/fusedwind/examples/turbine/cs_mesh_example.py
+++ b/src/fusedwind/examples/turbine/cs_mesh_example.py
@@ -1,0 +1,142 @@
+
+# --- 1 -----
+
+import numpy as np
+
+from openmdao.lib.datatypes.api import VarTree
+from openmdao.main.api import Assembly, Component
+
+from fusedwind.interface import implement_base
+from fusedwind.turbine.geometry import read_blade_planform, redistribute_blade_planform
+from fusedwind.turbine.configurations import configure_bladestructure, configure_bladesurface
+from fusedwind.turbine.blade_structure import SplinedBladeStructure
+from fusedwind.turbine.structure_vt import BladeStructureVT3D, Csys,\
+    CrossSectionAreasVT
+
+#top = Assembly()
+
+
+
+cs_areas = CrossSectionAreasVT()
+
+uniax = cs_areas.add_material('uniax')
+uniax.E1 = 41.63e9
+uniax.E2 = 14.93e9
+uniax.E3 = 14.93e9
+uniax.nu12 = 0.241
+uniax.nu13 = 0.241
+uniax.nu23 = 0.241
+uniax.G12 = 5.047e9
+uniax.G13 = 5.047e9
+uniax.G23 = 5.047e9
+uniax.rho = 1915.5
+
+biax = cs_areas.add_material('biax')
+biax.E1 = 13.92e9
+biax.E2 = 13.92e9
+biax.E3 = 13.92e9
+biax.nu12 = 0.533
+biax.nu13 = 0.533
+biax.nu23 = 0.533
+biax.G12 = 11.5e9
+biax.G13 = 4.539e9
+biax.G23 = 4.539e9
+biax.rho = 1845
+
+
+# add material coordinate systems
+esys_hori = cs_areas.add_csys('esys_hori') # for horizontal layers
+esys_hori.origin_x = 0.0
+esys_hori.origin_y = 0.0
+esys_hori.origin_z = 0.0
+esys_hori.theta_x = -90.0
+esys_hori.theta_y = 180.0
+esys_hori.theta_z = 90.0
+
+esys_vert = cs_areas.add_csys('esys_vert') # for -90deg oriented layers
+esys_vert.origin_x = 0.0
+esys_vert.origin_y = 0.0
+esys_vert.origin_z = 0.0
+esys_vert.theta_x = -180.0
+esys_vert.theta_y = 180.0
+esys_vert.theta_z = 90.0
+
+# add keypoints
+KP000 = cs_areas.add_kp('KP000')
+KP000.x = -0.1
+KP000.y = 0.1
+KP001 = cs_areas.add_kp('KP001')
+KP001.x = 0.1
+KP001.y = 0.1
+KP002 = cs_areas.add_kp('KP002')
+KP002.x = -0.1
+KP002.y = 0.05
+KP003 = cs_areas.add_kp('KP003')
+KP003.x = -0.1
+KP003.y = 0.05
+KP004 = cs_areas.add_kp('KP004')
+KP004.x = -0.05
+KP004.y = 0.05
+KP005 = cs_areas.add_kp('KP005')
+KP005.x = +0.05
+KP005.y = 0.05
+KP006 = cs_areas.add_kp('KP006')
+KP006.x = -0.1
+KP006.y = -0.05
+KP007 = cs_areas.add_kp('KP007')
+KP007.x = +0.1
+KP007.y = -0.05
+KP008 = cs_areas.add_kp('KP008')
+KP008.x = +0.1
+KP008.y = -0.1
+KP009 = cs_areas.add_kp('KP009')
+KP009.x = -0.1
+KP009.y = -0.1
+KP010 = cs_areas.add_kp('KP010')
+KP010.x = -0.05
+KP010.y = -0.05
+KP011 = cs_areas.add_kp('KP011')
+KP011.x = +0.05
+KP011.y = -0.05
+
+# add areas
+cap_up = cs_areas.add_area('cap_up')
+cap_up.KPs = ['KP003',
+              'KP002',
+              'KP001',
+              'KP000'
+              ]
+cap_up.mat_name = 'uniax'
+cap_up.esys_name = 'esys_hori'
+
+cap_low = cs_areas.add_area('cap_low')
+cap_low.KPs = ['KP009',
+              'KP009',
+              'KP007',
+              'KP006'
+              ]
+cap_low.mat_name = 'uniax'
+cap_low.esys_name = 'esys_hori'
+
+web = cs_areas.add_area('web')
+web.KPs = ['KP010',
+              'KP011',
+              'KP005',
+              'KP004'
+              ]
+web.mat_name = 'biax'
+web.esys_name = 'esys_vert'
+
+# HOWTO access dict object
+print cs_areas.csysts['esys_vert'].origin_x
+
+# HOWTO access list obejct
+kp = getattr(cs_areas, 'KP005')
+print kp.x
+print kp.y
+
+for kpname in cs_areas.KPs:
+    print kpname
+    kp = getattr(cs_areas, kpname)
+    print kp.x
+    print kp.y

--- a/src/fusedwind/turbine/blade_structure.py
+++ b/src/fusedwind/turbine/blade_structure.py
@@ -659,26 +659,6 @@ class SplinedBladeStructure(Assembly):
             for layer in region.layers:
                 region.thickness += np.maximum(0., getattr(region, layer).thickness)
 
-
-@implement_base(ModifyCrossSectionAreasBase)
-class LinearizedCrossSectionAreas(Assembly):
-    '''
-    Class for building a complete linear lines parameterized
-    representation of the blade structure.
-
-    Outputs a CrossSectionAreasVT3D vartree with a discrete
-    representation of the structural geometry.
-
-    '''
-    # TODO: implement linear interpolation method
-    x = Array(iotype='in', desc='spanwise resolution of blade')
-    span_ni = Int(20, iotype='in', desc='Number of discrete points along span')
-    areas3dIn = VarTree(CrossSectionAreasVT3D(), iotype='in',
-                                         desc='Vartree containing initial discrete definition of blade cross section areas')
-    areas3dOut = VarTree(CrossSectionAreasVT3D(), iotype='out',
-                                         desc='Vartree containing modified discrete definition of blade cross section areas')
-
-    
 @base
 class BladeStructureBuilderBase(Component):
     """

--- a/src/fusedwind/turbine/geometry_vt.py
+++ b/src/fusedwind/turbine/geometry_vt.py
@@ -72,7 +72,7 @@ class Curve(VariableTree):
             points[:, i] = self._splines[i](self.s)
 
         self.initialize(points)
-
+ 
 @base
 class AirfoilShape(Curve):
     """

--- a/src/fusedwind/turbine/rotoraero_vt.py
+++ b/src/fusedwind/turbine/rotoraero_vt.py
@@ -302,6 +302,7 @@ class LoadVectorArrayCaseList(VariableTree):
     List of load vector cases as function of span
     """
     cases = List(LoadVectorArray, desc='List of load cases')
+    # maro: why is this not a list of load case names according to the convention i.e.in structure_vt/BladeStructureVT3D
 
     def _interp_s(self, s):
         """

--- a/src/fusedwind/turbine/structure_vt.py
+++ b/src/fusedwind/turbine/structure_vt.py
@@ -488,20 +488,7 @@ class CrossSectionMeshVT(VariableTree):
     emat  = Array(desc='Material per element %s' % defs)
     matprops = Array(desc='Material properties (see docs)')
     elsets = Dict(desc='Dictionary of Elset vartrees')
-    
-#------------------------------------------------------------------------- @base
-#------------------------------------- class CrossSectionMeshVT3D(VariableTree):
-    #----------------------------------------------------------------------- '''
-    #-------------------------------------------------- Container for a 3D mesh.
-    #----------------------------------------------------------------------- '''
-    #--------------------- nl_3d = Array(desc='Nodal points (node nr, x, y, z)')
-    #------------------------ defs = '(Element number, node 1, n2, n3, ..., n8)'
-    #---------------------------------- el_3d = Array(desc='Elements %s' % defs)
-    #--------- defs = '(Element nr, material nr, fiber angle, fiberplane angle)'
-    #---------------------- emat  = Array(desc='Material per element %s' % defs)
-    #------------------- matprops = Array(desc='Material properties (see docs)')
-    #--------------------------- elsets = List(desc='List of element set names')
-    
+   
 @base
 class CrossSectionElementStressRecoveryVT(VariableTree):
     '''
@@ -509,16 +496,3 @@ class CrossSectionElementStressRecoveryVT(VariableTree):
     '''
     el_stresses = Dict(desc='element stresses') # List of ResultVectors
     el_strains = Dict(desc='element strains') # List of ResultVectors
-    
-#------------------------------------------------------------------------ #@base
-#---------------------------------------- #class CrossSectionMesh(VariableTree):
-    #----------------------------------------------------------------------- '''
-    #------------------------------------------ Container for Cross section mesh
-    #----------------------------------------------------------------------- '''
-    #------------------------ nl_2d = Array(desc='Nodal points (node nr, x, y)')
-    #------------------------ defs = '(Element number, node 1, n2, n3, ..., n8)'
-    #---------------------------------- el_2d = Array(desc='Elements %s' % defs)
-    #----------------------- elsets = Dict(desc='element sets') # Lsit of Elsets
-#------------------------------------------------------------------------------ 
-    #------- el_stresses = Dict(desc='element stresses') # List of ResultVectors
-#-------- #    el_strains = Dict(desc='element strains') # List of ResultVectors


### PR DESCRIPTION
I am proposing a "layer" between the current CrossSectionStructureVT (which is in its actual implementation more a CrossSectionLayupVT) and CrossSectionMeshVT: The CrossSectionAreasVT, which holds an internal representation of shellexpander such as the cross section discretization by Areas. These Areas contain KeyPoints, materials, fiber plane and fiber direction angles.

A possible workflow to create a 2D cross sectional BECAS mesh would then look like this:
- CrossSectionStructureVT - holds layup (regions, webs, materials airfoil)
- CrossSectionAreasVT - holds areas, keypoints, matprops, fiber plane and fiber direction angles (after expansion of the shell) [input for a mesher]
- CrossSectionMeshVT - holds nodes, elements, emats, matprops, elsets [input for BECAS]

The CrossSectionAreasVT gives us the freedom to define geometries and more detailed layups of blade sub-components such as trailing edges or web connections as alternative to CrossSectionStructureVT. If this step is integrated into the workflow described above, I think airfoil2becas and shellexpander would need to be split into sub-modules.
